### PR TITLE
Update test.yml to use more up-to-date Go versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        version: [ 'oldstable', 'stable' ]
     name: Test Go ${{ matrix.go }}
     steps:
       - uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.21', '1.22' ]
     name: Test Go ${{ matrix.go }}
     steps:
       - uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.19', '1.20' ]
+        go: [ '1.21', '1.22' ]
     name: Test Go ${{ matrix.go }}
     steps:
       - uses: actions/setup-go@v5


### PR DESCRIPTION
Update the PR/Push workflow to use more up-to-date versions of go.   I'm not sure why we are pinned to versions however...