### PR TITLE
Finish moving over to cfhttp/v2

### DIFF
--- a/driverhttp/handlers.go
+++ b/driverhttp/handlers.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 
-	cf_http_handlers "code.cloudfoundry.org/cfhttp/handlers"
+	cf_http_handlers "code.cloudfoundry.org/cfhttp/v2/handlers"
 	"code.cloudfoundry.org/dockerdriver"
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/tedsuo/rata"

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module code.cloudfoundry.org/dockerdriver
 go 1.19
 
 require (
-	code.cloudfoundry.org/cfhttp v2.0.0+incompatible
-	code.cloudfoundry.org/cfhttp/v2 v2.0.2
+	code.cloudfoundry.org/cfhttp/v2 v2.1.0
 	code.cloudfoundry.org/clock v1.1.0
 	code.cloudfoundry.org/goshims v0.35.0
 	code.cloudfoundry.org/lager/v3 v3.0.3

--- a/go.sum
+++ b/go.sum
@@ -592,10 +592,8 @@ cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoIS
 cloud.google.com/go/workflows v1.8.0/go.mod h1:ysGhmEajwZxGn1OhGOGKsTXc5PyxOc0vfKf5Af+to4M=
 cloud.google.com/go/workflows v1.9.0/go.mod h1:ZGkj1aFIOd9c8Gerkjjq7OW7I5+l6cSvT3ujaO/WwSA=
 cloud.google.com/go/workflows v1.10.0/go.mod h1:fZ8LmRmZQWacon9UCX1r/g/DfAXx5VcPALq2CxzdePw=
-code.cloudfoundry.org/cfhttp v2.0.0+incompatible h1:Gk1oNYalXmkebrG9kgUtZ9+FPjQGnqZtS457RP2gWhc=
-code.cloudfoundry.org/cfhttp v2.0.0+incompatible/go.mod h1:kwYQ8kChWl4AuUJG3vKtp1po2B91S7XoUWhoKElabmA=
-code.cloudfoundry.org/cfhttp/v2 v2.0.2 h1:V32WO2djBwD/Zxmjd8QF6kJdYeT/kMbK5MBHp3hyR0M=
-code.cloudfoundry.org/cfhttp/v2 v2.0.2/go.mod h1:JD6Dgp+240Z4lbsbOiqY3xjhX+W8zB/4x7pFwlNLcJI=
+code.cloudfoundry.org/cfhttp/v2 v2.1.0 h1:HbQ5H2R+HEKG/rcB6Gk3okeC3h2fAC4PPnLQoMHvzZM=
+code.cloudfoundry.org/cfhttp/v2 v2.1.0/go.mod h1:k9R36Y/9dUc9OsX4dfDuEjHZ7Q00ttklKQj6HD6h6+U=
 code.cloudfoundry.org/clock v1.1.0 h1:XLzC6W3Ah/Y7ht1rmZ6+QfPdt1iGWEAAtIZXgiaj57c=
 code.cloudfoundry.org/clock v1.1.0/go.mod h1:yA3fxddT9RINQL2XHS7PS+OXxKCGhfrZmlNUCIM6AKo=
 code.cloudfoundry.org/goshims v0.35.0 h1:2QJem6S/YfW7lHDalUsWyH80zoAF1gV89tir8b/myVQ=


### PR DESCRIPTION
This is a follow up PR to https://github.com/cloudfoundry/dockerdriver/pull/61

The newest version of `cfhttp` without any of the
deprecated code is: v2.1.0

[#187603786](https://www.pivotaltracker.com/story/show/187603786)